### PR TITLE
Add basic kinematic examples and test structure using catch2

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -1,0 +1,25 @@
+name: key4hep
+
+on: [push, pull_request]
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cvmfs-contrib/github-action-cvmfs@v2
+      - uses: aidasoft/run-lcg-view@v3
+        with:
+          view-path: '/cvmfs/sw.hsf.org/key4hep'
+          container: centos7
+          run: |
+            mkdir build install
+            cd build
+            cmake .. -DCMAKE_CXX_STANDARD=17 \
+              -DCMAKE_INSTALL_PREFIX=../install \
+              -DBUILD_TESTING=ON -DUSE_EXTERNAL_CATCH2=ON \
+              -G Ninja
+            ninja -k0
+            ctest --output-on-failure
+            ninja install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,19 @@ SET(${PROJECT_NAME}_VERSION_PATCH 0)
 SET(${PROJECT_NAME}_VERSION "${${PROJECT_NAME}_VERSION_MAJOR}.${${PROJECT_NAME}_VERSION_MINOR}.${${PROJECT_NAME}_VERSION_PATCH}")
 
 #--- Definitely need EDM4HEP data model library
-find_package(EDM4HEP)
+find_package(EDM4HEP REQUIRED)
+
+#--- Also need ROOT to use some of the useful physics libraries
+find_package(ROOT REQUIRED COMPONENTS Core Physics)
 
 #--- Define basic build settings -----------------------------------------------
 # - Use GNU-style hierarchy for installing build products
 include(GNUInstallDirs)
+
+set(CMAKE_CXX_STANDARD 17 CACHE STRING "")
+if (NOT CMAKE_CXX_STANDARD MATCHES "17|20")
+  message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")
+endif()
 
 if (${APPLE})
     set(CPP_STANDARD_FLAGS "-std=c++${CMAKE_CXX_STANDARD}\ -stdlib=libc++")
@@ -42,11 +50,6 @@ if(NOT CMAKE_CONFIGURATION_TYPES)
   endif()
 endif()
 
-set(CMAKE_CXX_STANDARD 17 CACHE STRING "")
-if (NOT CMAKE_CXX_STANDARD MATCHES "17")
-  message(FATAL_ERROR "Unsupported C++ standard: ${CMAKE_CXX_STANDARD}")
-endif()
-
 #--- enable unit testing capabilities ------------------------------------------
 include(CTest)
 
@@ -70,3 +73,33 @@ install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE
 
 #--- add CMake infrastructure
 include(cmake/EDM4HEPUtilsCreateConfig.cmake)
+
+
+add_subdirectory(edm4hep)
+
+if (BUILD_TESTING)
+  option(USE_EXTERNAL_CATCH2 "Link against an external Catch2 v3 static library, otherwise build it locally" OFF)
+  if (USE_EXTERNAL_CATCH2)
+    find_package(Catch2 REQUIRED)
+  else()
+    message(STATUS "Fetching local copy of Catch2 library for unit-tests...")
+
+    Include(FetchContent)
+    FetchContent_Declare(
+      Catch2
+      GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+      GIT_TAG        037ddbc75cc5e58b93cf5a010a94b32333ad824d
+      )
+    FetchContent_MakeAvailable(Catch2)
+    set(CMAKE_MODULE_PATH ${Catch2_SOURCE_DIR}/extras ${CMAKE_MODULE_PATH})
+
+    # Hack around the fact, that the include directories are not declared as
+    # SYSTEM for the targets defined this way. Otherwise warnings can still occur
+    # in Catch2 code when templates are evaluated (which happens quite a bit)
+    get_target_property(CATCH2_IF_INC_DIRS Catch2 INTERFACE_INCLUDE_DIRECTORIES)
+    set_target_properties(Catch2 PROPERTIES INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${CATCH2_IF_INC_DIRS}")
+  endif()
+
+  include(Catch)
+  add_subdirectory(tests)
+endif()

--- a/cmake/EDM4HEPUtilsConfig.cmake.in
+++ b/cmake/EDM4HEPUtilsConfig.cmake.in
@@ -16,9 +16,14 @@ find_dependency(EDM4HEP REQUIRED)
 
 # - Include the targets file to create the imported targets that a client can
 # link to (libraries) or execute (programs)
-# TODO: need targets first
-# include("${CMAKE_CURRENT_LIST_DIR}/EDM4HEPUtilsTargets.cmake")
+# TODO: At some point maybe we have a more general target here?
+if(NOT TARGET EDM4HEPUtils::kinematics)
+  include("${CMAKE_CURRENT_LIST_DIR}/EDM4HEPUtilsTargets.cmake")
+endif()
+
+check_required_components(EDM4HEPUtils)
 
 # print the default "Found:" message and check library location
 include(FindPackageHandleStandardArgs)
-# TODO: need targets first before we can do anything here
+get_property(TEST_UTILS_LIBRARY TARGET EDM4HEPUtils::kinematics PROPERTY INTERFACE_INCLUDE_DIRECTORIES)
+find_package_handle_standard_args(EDM4HEPUtils DEFAULT_MSG CMAKE_CURRENT_LIST_FILE TEST_UTILS_LIBRARY)

--- a/edm4hep/CMakeLists.txt
+++ b/edm4hep/CMakeLists.txt
@@ -1,0 +1,13 @@
+add_library(kinematics INTERFACE)
+target_include_directories(kinematics
+  INTERFACE $<BUILD_INTERFACE:${${PROJECT_NAME}_SOURCE_DIR}>
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+target_link_libraries(kinematics PUBLIC INTERFACE ROOT::Core)
+target_compile_features(kinematics INTERFACE cxx_std_17)
+
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/edm4hep/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/edm4hep
+  PATTERN "CMakeLists.txt" EXCLUDE)
+
+install(TARGETS kinematics
+  EXPORT EDM4HEPUtilsTargets
+  )

--- a/edm4hep/utils/kinematics.h
+++ b/edm4hep/utils/kinematics.h
@@ -1,0 +1,101 @@
+#ifndef EDM4HEP_UTILS_KINEMATICS_H
+#define EDM4HEP_UTILS_KINEMATICS_H
+
+#include "Math/Vector4D.h"
+
+#include <cmath>
+
+namespace edm4hep {
+/**
+ * A LorentzVector with (px, py, pz) and M
+ */
+using LorentzVectorM = ROOT::Math::PxPyPzMVector;
+
+/**
+ * A LorentzVector with (px, py, pz) and E
+ */
+using LorentzVectorE = ROOT::Math::PxPyPzEVector;
+
+namespace utils {
+
+/**
+ * Get the transverse momentum from a Particle
+ */
+template<typename ParticleT>
+inline float pT(ParticleT const& p) {
+  return std::sqrt(p.getMomentum()[0] * p.getMomentum()[0] + p.getMomentum()[1] * p.getMomentum()[1]);
+}
+
+/**
+ * Get the transverse momentum from a Particle
+ */
+template<typename ParticleT>
+inline float pt(ParticleT const& p) {
+  return pT(p);
+}
+
+/**
+ * Get the total momentum from a Particle
+ */
+template<typename ParticleT>
+inline float p(ParticleT const& part) {
+  const auto mom = part.getMomentum();
+  return std::sqrt(mom[0]*mom[0] + mom[1]*mom[1] + mom[2]*mom[2]);
+}
+
+namespace impl {
+/**
+ * Tag struct for getting 4-momenta with momentum + mass
+ */
+struct UseMassTag {
+  using type = ::edm4hep::LorentzVectorM;
+};
+
+/**
+ * Tag struct for getting 4-moment with momentum + energy
+ */
+struct UseEnergyTag {
+  using type = ::edm4hep::LorentzVectorE;
+};
+
+/**
+ * Tag-dispatched implementation for getting the 4-momentum from a particle
+ * according to the desired type.
+ */
+template<typename ParticleT, typename LorentzVectorTypeTag>
+inline typename LorentzVectorTypeTag::type p4(ParticleT const& part, LorentzVectorTypeTag*) {
+  const auto mom = part.getMomentum();
+  if constexpr(std::is_same_v<typename LorentzVectorTypeTag::type, LorentzVectorM>) {
+    return LorentzVectorM{mom[0], mom[1], mom[2], part.getMass()};
+  }
+  if constexpr(std::is_same_v<typename LorentzVectorTypeTag::type, LorentzVectorE>) {
+    return LorentzVectorE{mom[0], mom[1], mom[2], part.getEnergy()};
+  }
+}
+} // namespace impl
+
+/**
+ * Static tag to select the mass in 4 momentum vectors
+ */
+constexpr static impl::UseMassTag UseMass;
+
+/**
+ * Static tag to select the energy in 4 momentum vectors
+ */
+constexpr static impl::UseEnergyTag UseEnergy;
+
+/**
+ * Get the 4 momentum vector from a Particle. By default using the momentum and
+ * the mass, but can be switched to using the energy when using the UseEnergy as
+ * second argument.
+ */
+template<typename ParticleT, typename LorentzVectorTag=impl::UseMassTag>
+inline typename LorentzVectorTag::type p4(ParticleT const& part, LorentzVectorTag tag=UseMass) {
+  return impl::p4(part, &tag);
+}
+
+
+}} // namespace edm4hep::utils
+
+
+#endif

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_executable(unittests
+  test_kinematics.cpp
+  )
+
+target_link_libraries(unittests EDM4HEP::edm4hep kinematics Catch2::Catch2 Catch2::Catch2WithMain)
+
+catch_discover_tests(unittests)

--- a/tests/test_kinematics.cpp
+++ b/tests/test_kinematics.cpp
@@ -1,0 +1,93 @@
+#define CATCH_CONFIG_FAST_COMPILE
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include "edm4hep/utils/kinematics.h"
+
+#include "edm4hep/MCParticle.h"
+#include "edm4hep/ReconstructedParticle.h"
+
+#include "Math/Vector4D.h"
+
+#include <tuple>
+
+using ParticleTypes = std::tuple<edm4hep::MCParticle, edm4hep::ReconstructedParticle>;
+
+TEMPLATE_LIST_TEST_CASE( "Transverse momentum works on MC and Reco Particles", "[pT][kinematics]", ParticleTypes)
+{
+  using namespace edm4hep;
+  TestType particle;
+
+  particle.setMomentum({3.0f, 4.0f, 0.0f});
+  REQUIRE(utils::pT(particle) == 5.0f);
+
+  particle.setMomentum({3.0f, 4.0f, 125.0f});
+  REQUIRE(utils::pT(particle) == 5.0f);
+
+  particle.setMomentum({-3.0f, 4.0f, 10.0f});
+  REQUIRE(utils::pt(particle) == 5.0f);
+
+  particle.setMomentum({-4.0f, -3.0f, std::nan("")});
+  REQUIRE(utils::pt(particle) == 5.0f);
+
+  particle.setMomentum({std::nan(""), -3.0f, 0});
+  REQUIRE(std::isnan(utils::pt(particle)));
+}
+
+TEMPLATE_LIST_TEST_CASE( "Momentum works on MC and Reco particles", "[p][kinematics]", ParticleTypes )
+{
+  using namespace edm4hep;
+  TestType particle;
+
+  particle.setMomentum({1.0f, 2.0f, 3.0f});
+  REQUIRE(utils::p(particle) == Catch::Approx(std::sqrt(14)));
+
+  particle.setMomentum({1.0f, -2.0f, 3.0f});
+  REQUIRE(utils::p(particle) == Catch::Approx(std::sqrt(14)));
+
+  particle.setMomentum({1.0f, 2.0f, -3.0f});
+  REQUIRE(utils::p(particle) == Catch::Approx(std::sqrt(14)));
+
+  particle.setMomentum({-12.0f, 0.0f, 0.0f});
+  REQUIRE(utils::p(particle) == 12.0f);
+
+  particle.setMomentum({0.0f, -10.0f, -10.f});
+  REQUIRE(utils::p(particle) == Catch::Approx(std::sqrt(200.0)));
+
+  particle.setMomentum({std::nan(""), 2.0f, 3.0f});
+  REQUIRE(std::isnan(utils::p(particle)));
+}
+
+TEST_CASE( "4 momentum works on MC Particles", "[p4][kinematics][MCParticle]" )
+{
+  using namespace edm4hep;
+  MCParticle particle;
+  particle.setMomentum({1.0f, 2.0f, 3.0f});
+  particle.setMass(42);
+  REQUIRE(utils::p4(particle) == LorentzVectorM{1, 2, 3, 42});
+
+  // this basically just tests that the internal calculation of the energy works as expected
+  REQUIRE(utils::p4(particle, utils::UseEnergy) == LorentzVectorE{1, 2, 3, std::sqrt(14 + 42*42)});
+}
+
+TEST_CASE( "4 momentum works on Reco Particles", "[p4][kinematics][ReconstructedParticle]" )
+{
+  using namespace edm4hep;
+  ReconstructedParticle particle;
+  particle.setMomentum({1.0f, 2.0f, 3.0f});
+  particle.setMass(125);
+
+  // By default we use the mass
+  REQUIRE(utils::p4(particle) == LorentzVectorM{1, 2, 3, 125});
+
+  // In the case of ReconstructedParticle, the 4-momentum state is not kept
+  // consistent internally! So, when using the energy we will have a different 4
+  // momentum vector
+  REQUIRE(utils::p4(particle, utils::UseEnergy) == LorentzVectorE{1, 2, 3, 0});
+
+  // Setting the Energy does not affect the mass
+  particle.setEnergy(42);
+  REQUIRE(utils::p4(particle, utils::UseMass) == LorentzVectorM{1, 2, 3, 125});
+  REQUIRE(utils::p4(particle, utils::UseEnergy) == LorentzVectorE{1, 2, 3, 42});
+}

--- a/tests/test_kinematics.cpp
+++ b/tests/test_kinematics.cpp
@@ -91,3 +91,21 @@ TEST_CASE( "4 momentum works on Reco Particles", "[p4][kinematics][Reconstructed
   REQUIRE(utils::p4(particle, utils::UseMass) == LorentzVectorM{1, 2, 3, 125});
   REQUIRE(utils::p4(particle, utils::UseEnergy) == LorentzVectorE{1, 2, 3, 42});
 }
+
+TEST_CASE( "4 momentum works with user set values", "[p4][kinematics][user set values]" ) {
+  using namespace edm4hep;
+  ReconstructedParticle particle;
+  particle.setMomentum({1.0f, 2.0f, 3.0f});
+  particle.setMass(125.0f);
+  particle.setEnergy(42.0f);
+
+  // Requiring a dedicated mass value gives us a 4-vector with that mass value
+  REQUIRE(utils::p4(particle, utils::SetMass{3.096f}) == LorentzVectorM{1.0f, 2.0f, 3.0f, 3.096f});
+  // The mass of the particle itself remains unchanged!
+  REQUIRE(particle.getMass() == 125.f);
+
+  // Similar with the energy, if we want a dedicated value we get it in the 4 vector
+  REQUIRE(utils::p4(particle, utils::SetEnergy{1.23f}) == LorentzVectorE{1.0f, 2.0f, 3.0f, 1.23f});
+  // But the underlying particle energy remains unchanged
+  REQUIRE(particle.getEnergy() == 42.f);
+}


### PR DESCRIPTION
BEGINRELEASENOTES
- Added basic functionality to get some kinematics from particles.
- Added basic unittest setup using catch2 v3 and linking against the static library, which is built on the fly by default
- Added cmake config for properly exporting this for downstream usage, now that we actually have a target to export.

ENDRELEASENOTES

This is just a first PR to start and populate this repository. In it's current form some core utility functionality would be available via

```cpp
#include "edm4hep/utils/kinematics.h"
```
All functionality in there is placed in namespace `edm4hep::utils`. Obviously all of this is up for discussion, and this should mainly serve as a starting point. At the moment there are only some simple kinematic functions, but I suppose we should get the basic structure hashed out at the start in order to avoid major restructurings later.

For testing I am currently using catch2, which is required via `find_package` in case the tests are built. In principle we could also build this on the fly if necessary, but wrt spack it might be better to have this as a "true external" dependency for the tests.
